### PR TITLE
fix on_batch_end to update lr after logging

### DIFF
--- a/clr_callback.py
+++ b/clr_callback.py
@@ -121,14 +121,11 @@ class CyclicLR(Callback):
         logs = logs or {}
         self.trn_iterations += 1
         self.clr_iterations += 1
-        K.set_value(self.model.optimizer.lr, self.clr())
 
         self.history.setdefault('lr', []).append(K.get_value(self.model.optimizer.lr))
         self.history.setdefault('iterations', []).append(self.trn_iterations)
 
         for k, v in logs.items():
             self.history.setdefault(k, []).append(v)
-            
-            
-
-  
+        
+        K.set_value(self.model.optimizer.lr, self.clr())


### PR DESCRIPTION
Hi, 

When I first used this implementation I was confused why the learning rate wasn't starting at the specified base learning rate. For example:

```
# Define the learning rate finder
steps_per_epoch = np.ceil(60000/256)
epochs = 2

lr_finder = CyclicLR(base_lr=1e-6, max_lr=3e-2, mode='triangular', step_size=steps_per_epoch*epochs)

# Fit a model
model.fit(x_train, y_train,
                batch_size=256,
                epochs=epochs,
                callbacks=[lr_finder])
```

When I inspect the logs after training I see the following:

```
h = lr_finder.history
iters = h['iterations']
lr = h['lr']
acc = h['acc']
loss = h['loss']

lr[0]
> 6.4997868e-05
```

I would expect that the first batch would be trained on the first learning rate (and in fact it is, it's just not getting logged properly). I finally realized that you were updating the model's learning rate _before_ logging the information from the last batch. 

```
def on_batch_end(self, epoch, logs=None):

    logs = logs or {}
    self.trn_iterations += 1
    self.clr_iterations += 1
    K.set_value(self.model.optimizer.lr, self.clr())   # ATTN: changing the learning rate before logging

    self.history.setdefault('lr', []).append(K.get_value(self.model.optimizer.lr))
    self.history.setdefault('iterations', []).append(self.trn_iterations)

    for k, v in logs.items():
        self.history.setdefault(k, []).append(v)
```

I have created a PR to fix this.