### PR TITLE
Log learning rate.

### DIFF
--- a/clr_callback.py
+++ b/clr_callback.py
@@ -129,3 +129,7 @@ class CyclicLR(Callback):
             self.history.setdefault(k, []).append(v)
         
         K.set_value(self.model.optimizer.lr, self.clr())
+        
+    def on_epoch_end(self, epoch, logs=None):
+        logs = logs or {}
+        logs['lr'] = K.get_value(self.model.optimizer.lr)


### PR DESCRIPTION
Logs the learning rate in tensorboard, just like the Keras callback ReduceLROnPlateau does (see [https://github.com/keras-team/keras/blob/master/keras/callbacks.py](url)).